### PR TITLE
Fix docker sample configs

### DIFF
--- a/source/setup-elixir.md
+++ b/source/setup-elixir.md
@@ -43,7 +43,7 @@ The proxy uses a JSON object to get configuration information. If the configurat
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/setup-java.md
+++ b/source/setup-java.md
@@ -43,7 +43,7 @@ The proxy uses a JSON object to get configuration information. If the configurat
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/setup-node.md
+++ b/source/setup-node.md
@@ -159,7 +159,7 @@ The proxy uses a JSON object to get configuration information. If the configurat
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/setup-ruby.md
+++ b/source/setup-ruby.md
@@ -43,7 +43,7 @@ The standalone proxy uses a JSON file placed in your applications root folder to
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/setup-scala.md
+++ b/source/setup-scala.md
@@ -43,7 +43,7 @@ The proxy uses a JSON object to get configuration information. If the configurat
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/standalone-proxy.md
+++ b/source/standalone-proxy.md
@@ -28,7 +28,7 @@ Create a JSON configuration file:
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }

--- a/source/troubleshooting.md
+++ b/source/troubleshooting.md
@@ -59,7 +59,7 @@ These are sample configurations for Engine based on the server environment you a
   ],
   "frontends": [
     {
-      "host": "127.0.0.1",
+      "host": "0.0.0.0",
       "port": 3001,
       "endpoint": "/graphql"
     }


### PR DESCRIPTION
When engine is running in a docker container, `127.0.0.1` refers to the
loopback address _inside_ the container.

Binding to `0.0.0.0` uses every address inside the container, which is
rqeuired for port-forwarding out.