### PR TITLE
Updated links in troubleshooting doc

### DIFF
--- a/source/troubleshooting.md
+++ b/source/troubleshooting.md
@@ -27,7 +27,7 @@ apollo-tracing 0.0.9+
 
 <h3> Check for Engine configuration validity </h3>
 
-These are sample configurations for Engine based on the server environment you are using. A comprehensive documentation on the configurations are available [here](proto-doc.html)  Use these as a guide to validate your configuration.
+These are sample configurations for Engine based on the server environment you are using. A comprehensive documentation on the configurations are available [here](proto-doc.md)  Use these as a guide to validate your configuration.
 
 **Node sidecar**
 ```

--- a/source/troubleshooting.md
+++ b/source/troubleshooting.md
@@ -9,7 +9,7 @@ If you hit any issues in setting up Engine for your GraphQL service, we're here 
 
 <h3> Check that you are on a supported GraphQL server </h3>
 
-Check that your server is one of the supported GraphQL servers listed [here](index.html#apollo-tracing).
+Check that your server is one of the supported GraphQL servers listed [here](index.md#apollo-tracing).
 
 If it is, please upgrade to the latest released versions of the GraphQL Server, Engine and Apollo packages.
 


### PR DESCRIPTION
I updated broken links for the list of supported servers and proto-doc in the troubleshooting.md file.