### PR TITLE
Release/2018.02 2 g0b77ff3e3

### DIFF
--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -154,21 +154,7 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders | repeated  [Config.Origin.HTTP.OverrideRequestHeadersEntry](#mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry)  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
-
-
-
-
-<a name="mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry"/>
-
-### Config.Origin.HTTP.OverrideRequestHeadersEntry
-
-
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| key |  string |  |
-| value |  string |  |
+| overrideRequestHeaders | map[string]string  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
 
 
 

--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -154,7 +154,21 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders | map[string]string  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+| overrideRequestHeaders | repeated  [Config.Origin.HTTP.OverrideRequestHeadersEntry](#mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry)  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+
+
+
+
+<a name="mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry"/>
+
+### Config.Origin.HTTP.OverrideRequestHeadersEntry
+
+
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| key |  string |  |
+| value |  string |  |
 
 
 

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -3,6 +3,11 @@ title: Proxy release notes
 order: 20
 ---
 
+### 2018.02-2-g0b77ff3e3 – 2018-02-05
+
+* Fixed a bug where `Host` header was still not forwarded to origin servers if present.
+* Exposes stats field to better track engineproxy memory usage
+
 ### 2018.01-54-gce490265c - 2018-01-31
 
 * Fixed a bug where the `Host` header was not forwarded to origin servers. If the `Host` header is present, it will also be sent in the `X-Forwarded-Host` header. Both of these header values can be overridden via the field mentioned below.

--- a/source/setup-elixir.md
+++ b/source/setup-elixir.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-java.md
+++ b/source/setup-java.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-lambda.md
+++ b/source/setup-lambda.md
@@ -79,7 +79,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 This will make the Engine proxy available at `http://localhost:3001`.

--- a/source/setup-node.md
+++ b/source/setup-node.md
@@ -222,7 +222,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 You can deploy and manage your Engine proxy anywhere Docker containers can be hosted. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-ruby.md
+++ b/source/setup-ruby.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-scala.md
+++ b/source/setup-scala.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/standalone-proxy.md
+++ b/source/standalone-proxy.md
@@ -52,7 +52,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.01-54-gce490265c
+  gcr.io/mdg-public/engine:2018.02-2-g0b77ff3e3
 ```
 
 


### PR DESCRIPTION
- Release new version of Engineproxy that might finally fully squash the `Host` header bug