### PR TITLE
Release/2018.02 72 g882e543b9

### DIFF
--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -67,7 +67,7 @@ Frontend defines a web server run by the Proxy. The Proxy will listen on each fr
 | endpoint |  string | URL path on which to listen; often "/graphql". *Deprecated:* use `endpoints`. |
 | endpoints | repeated string | URL paths on which to listen; often `["/graphql"]`. |
 | originName |  string | Name of origin to serve with this frontend. The Proxy will also pass any HTTP requests sent to paths not in `endpoints`/`endpoint` to this origin. If not defined, defaults to the empty string, which is a valid origin name. |
-| endpointMap |  map<string, string> | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
+| endpointMap |  map&lt;string, string&gt; | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
 | extensions |   [Config.Frontend.Extensions](#mdg.engine.config.proto.Config.Frontend.Extensions)  | Configuration for GraphQL response extensions. |
 
 
@@ -156,7 +156,7 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders |  map<string, string> | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+| overrideRequestHeaders |  map&lt;string, string&gt; | If set, requests to this origin will have these headers replaced (or added) with the given values. |
 
 
 

--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -67,22 +67,8 @@ Frontend defines a web server run by the Proxy. The Proxy will listen on each fr
 | endpoint |  string | URL path on which to listen; often "/graphql". *Deprecated:* use `endpoints`. |
 | endpoints | repeated string | URL paths on which to listen; often `["/graphql"]`. |
 | originName |  string | Name of origin to serve with this frontend. The Proxy will also pass any HTTP requests sent to paths not in `endpoints`/`endpoint` to this origin. If not defined, defaults to the empty string, which is a valid origin name. |
-| endpointMap | repeated  [Config.Frontend.EndpointMapEntry](#mdg.engine.config.proto.Config.Frontend.EndpointMapEntry)  | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
+| endpointMap | map[string]string | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
 | extensions |   [Config.Frontend.Extensions](#mdg.engine.config.proto.Config.Frontend.Extensions)  | Configuration for GraphQL response extensions. |
-
-
-
-
-<a name="mdg.engine.config.proto.Config.Frontend.EndpointMapEntry"/>
-
-### Config.Frontend.EndpointMapEntry
-
-
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| key |  string |  |
-| value |  string |  |
 
 
 
@@ -170,21 +156,7 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders | repeated  [Config.Origin.HTTP.OverrideRequestHeadersEntry](#mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry)  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
-
-
-
-
-<a name="mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry"/>
-
-### Config.Origin.HTTP.OverrideRequestHeadersEntry
-
-
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| key |  string |  |
-| value |  string |  |
+| overrideRequestHeaders | map[string]string  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
 
 
 
@@ -340,9 +312,3 @@ Enum describing which GraphQL transport protocol is implemented by an origin. If
 | ----- | ----------- |
 | JSON | The standard JSON GraphQL transport is documented [here](http://graphql.org/learn/serving-over-http/#post-request) |
 | CBOR | GraphQL transport over CBOR is supported by Apollo Engine Proxy but not yet documented. |
-
-
-
-
-
-

--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -67,7 +67,7 @@ Frontend defines a web server run by the Proxy. The Proxy will listen on each fr
 | endpoint |  string | URL path on which to listen; often "/graphql". *Deprecated:* use `endpoints`. |
 | endpoints | repeated string | URL paths on which to listen; often `["/graphql"]`. |
 | originName |  string | Name of origin to serve with this frontend. The Proxy will also pass any HTTP requests sent to paths not in `endpoints`/`endpoint` to this origin. If not defined, defaults to the empty string, which is a valid origin name. |
-| endpointMap | map[string]string | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
+| endpointMap |  map<string, string> | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
 | extensions |   [Config.Frontend.Extensions](#mdg.engine.config.proto.Config.Frontend.Extensions)  | Configuration for GraphQL response extensions. |
 
 
@@ -156,7 +156,7 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders | map[string]string  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+| overrideRequestHeaders |  map<string, string> | If set, requests to this origin will have these headers replaced (or added) with the given values. |
 
 
 
@@ -312,3 +312,9 @@ Enum describing which GraphQL transport protocol is implemented by an origin. If
 | ----- | ----------- |
 | JSON | The standard JSON GraphQL transport is documented [here](http://graphql.org/learn/serving-over-http/#post-request) |
 | CBOR | GraphQL transport over CBOR is supported by Apollo Engine Proxy but not yet documented. |
+
+
+
+
+
+

--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -67,8 +67,22 @@ Frontend defines a web server run by the Proxy. The Proxy will listen on each fr
 | endpoint |  string | URL path on which to listen; often "/graphql". *Deprecated:* use `endpoints`. |
 | endpoints | repeated string | URL paths on which to listen; often `["/graphql"]`. |
 | originName |  string | Name of origin to serve with this frontend. The Proxy will also pass any HTTP requests sent to paths not in `endpoints`/`endpoint` to this origin. If not defined, defaults to the empty string, which is a valid origin name. |
-| endpointMap | map[string]string | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
+| endpointMap | repeated  [Config.Frontend.EndpointMapEntry](#mdg.engine.config.proto.Config.Frontend.EndpointMapEntry)  | Map from URL path to origin name. Use this field instead of `endpoints` and `originName` if you want different URL paths on this frontend to serve different origins. If you use this field, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. |
 | extensions |   [Config.Frontend.Extensions](#mdg.engine.config.proto.Config.Frontend.Extensions)  | Configuration for GraphQL response extensions. |
+
+
+
+
+<a name="mdg.engine.config.proto.Config.Frontend.EndpointMapEntry"/>
+
+### Config.Frontend.EndpointMapEntry
+
+
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| key |  string |  |
+| value |  string |  |
 
 
 
@@ -156,7 +170,21 @@ Configuration for forwarding GraphQL queries to an HTTP endpoint.
 | maxIdleConnections |   [uint64](#uint64)  | Maximum number of idle connections to keep open. If not specified, this will default to 100. |
 | trustedCertificates |  string | File path to load trusted X509 CA certificates. This should not be required if your HTTPS origin works in modern browsers. Certificates must be PEM encoded, and multiple certificates can be concatenated into a single file. If specified, only servers with a trust chain to these certificates will be accepted. If not specified, this will default to a certificate bundle included with the proxy binary, which is extracted from Ubuntu Linux. |
 | disableCertificateCheck |  bool | If set, X509 certificate validity (issuer, hostname, expiration) is not verified. This is very insecure, and should only be used for testing. |
-| overrideRequestHeaders | map[string]string  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+| overrideRequestHeaders | repeated  [Config.Origin.HTTP.OverrideRequestHeadersEntry](#mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry)  | If set, requests to this origin will have these headers replaced (or added) with the given values. |
+
+
+
+
+<a name="mdg.engine.config.proto.Config.Origin.HTTP.OverrideRequestHeadersEntry"/>
+
+### Config.Origin.HTTP.OverrideRequestHeadersEntry
+
+
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| key |  string |  |
+| value |  string |  |
 
 
 
@@ -312,3 +340,9 @@ Enum describing which GraphQL transport protocol is implemented by an origin. If
 | ----- | ----------- |
 | JSON | The standard JSON GraphQL transport is documented [here](http://graphql.org/learn/serving-over-http/#post-request) |
 | CBOR | GraphQL transport over CBOR is supported by Apollo Engine Proxy but not yet documented. |
+
+
+
+
+
+

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -3,6 +3,11 @@ title: Proxy release notes
 order: 20
 ---
 
+### 2018.02-72-g882e543b9 - 2018-02-22
+
+* Added support for receiving client-provided GraphQL extensions such as `persistedQuery` over GET requests. To use GET requests (with or without persisted queries), we recommend you upgrade to [`apollo-link-http` 1.5.0](https://www.npmjs.com/package/apollo-link-http) and pass `useGETForQueries: true` to `createHttpLink` in your client code.
+* Improve error messages for GraphQL request parse failures and for several common configuration problems.
+
 ### 2018.02-50-gef2fc6d4e - 2018-02-15
 
 * Add support for proxying non-GraphQL requests with Lambda origins. This allows serving GraphiQL directly from a Lambda handler.

--- a/source/setup-elixir.md
+++ b/source/setup-elixir.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-java.md
+++ b/source/setup-java.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-lambda.md
+++ b/source/setup-lambda.md
@@ -79,7 +79,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 This will make the Engine proxy available at `http://localhost:3001`.

--- a/source/setup-node.md
+++ b/source/setup-node.md
@@ -222,7 +222,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 You can deploy and manage your Engine proxy anywhere Docker containers can be hosted. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-ruby.md
+++ b/source/setup-ruby.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/setup-scala.md
+++ b/source/setup-scala.md
@@ -70,7 +70,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 It does not matter where you choose to deploy and manage your Engine proxy. We run our own on Amazon's [EC2 Container Service](https://aws.amazon.com/ecs/).

--- a/source/standalone-proxy.md
+++ b/source/standalone-proxy.md
@@ -52,7 +52,7 @@ engine_config_path=/path/to/engine.json
 proxy_frontend_port=3001
 docker run --env "ENGINE_CONFIG=$(cat "${engine_config_path}")" \
   -p "${proxy_frontend_port}:${proxy_frontend_port}" \
-  gcr.io/mdg-public/engine:2018.02-50-gef2fc6d4e
+  gcr.io/mdg-public/engine:2018.02-72-g882e543b9
 ```
 
 


### PR DESCRIPTION
- apollo-link-http@1.4.1 is not yet released; @evans will do this today (and I won't merge this until that's ready)
- I left out the hopefully-non-user-affecting changes mdg-private/monorepo#688 (proto timestamp unification) and mdg-private/monorepo#694 and mdg-private/monorepo#705 (upgrade Go from 1.9 to 1.0)

I am highly tempted to spend half an hour fixing https://github.com/pseudomuto/protoc-gen-doc/issues/340 but this is probably not the best use of my time.