### PR TITLE
Remove unnecessary `order` attribute from YAML front matter.

### DIFF
--- a/source/1.0-migration.md
+++ b/source/1.0-migration.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrade to apollo-engine 1.0
-order: 10
 ---
 
 Version 1.0 of the npm `apollo-engine` package replaces the `Engine` API with a streamlined `ApolloEngine` API. It's straightforward to upgrade your app to the 1.0 API.

--- a/source/error-tracking.md
+++ b/source/error-tracking.md
@@ -1,6 +1,5 @@
 ---
 title: Error Tracking
-order: 3
 ---
 
 The Engine proxy service is designed to accept traces, or resolver execution timings, from your application anytime there is an error, along with various samples of total requests, and bucket these by service time percentile. While the total number of requests are sampled and shown as a percentage of total incoming requests, all errors will be included and shown in the final collection.

--- a/source/proto-doc.md
+++ b/source/proto-doc.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy configuration
-order: 20
 ---
 
 The Engine Proxy has many configuration options. While all you need to set to get started is your `apiKey`, many aspects of the Proxy's behavior can be fine-tuned. This page describes all the available options.

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -1,6 +1,5 @@
 ---
 title: Proxy release notes
-order: 20
 ---
 
 <h2>Proxy release notes</h2>

--- a/source/setup-lambda.md
+++ b/source/setup-lambda.md
@@ -1,6 +1,5 @@
 ---
 title: AWS Lambda
-order: 2
 ---
 
 To get started with Engine for AWS Lambda, you will need to:

--- a/source/setup-virtual.md
+++ b/source/setup-virtual.md
@@ -2,7 +2,6 @@
 title: Setup for PaaS Hosting Environments (e.g. Heroku)
 sidebar_title: PaaS (e.g. Heroku)
 description: Get Engine running with your virtually hosted GraphQL server.
-order: 2
 ---
 
 To get started with Engine, you will need to:

--- a/source/troubleshooting.md
+++ b/source/troubleshooting.md
@@ -1,6 +1,5 @@
 ---
 title: Setup Troubleshooting
-order: 3
 ---
 
 If you hit any issues in setting up Engine for your GraphQL service, we're here to help! First, follow these troubleshooting steps to check for any obvious issues. If these don't help, please submit a support ticket to [support@apollographql.com](mailto:support@apollographql.com) and we'll work with you to get you up and running!

--- a/source/upgrade-optics.md
+++ b/source/upgrade-optics.md
@@ -1,6 +1,5 @@
 ---
 title: Upgrade from Optics Agent
-order: 11
 ---
 
 Apollo Engine is the next generation of Optics with new features like error reporting, query caching, and more. To enable support for more GraphQL server languages and unlock features like caching, Engine is built upon a proxy architecture. To upgrade from Optics to Engine you'll need to add the Engine proxy to your stack.


### PR DESCRIPTION
The order of pages is determined, in a much more manageable way than
arbitrarily picking numbers, using `sidebar_categories` in the (Hexo)
`_config.yml` for this deployment.

Therefore, these `order`s are just confusing.