### PR TITLE
Two formatting fixes for v0.8.10 release notes.

### DIFF
--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -56,6 +56,7 @@ No additional configuration is required to start using this feature.
 * Bugfix to automatic config reloading.
 
 <h2 id="v0.8.10" title="v0.8.10">0.8.10 - 2018-02-12</h2>
+
 * Added support for GZIP content encoding for responses from Lambda origins.
 * Added support for function qualifiers for Lambda origins.
 * Allows per-endpoint origin specification on frontends via `endpointMap`, a &lt;string,string&gt; map from endpoint path to `originName`. Users can use this field instead of `endpoints` and `originName` to route different URL paths on a frontend to serve different origins. If `endpointMap` is set, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. The proxy will also verify that only one of `endpoint` [deprecated], `endpoints`, and `endpointMap` are set.

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -60,7 +60,6 @@ No additional configuration is required to start using this feature.
 * Added support for GZIP content encoding for responses from Lambda origins.
 * Added support for function qualifiers for Lambda origins.
 * Allows per-endpoint origin specification on frontends via `endpointMap`, a &lt;string,string&gt; map from endpoint path to `originName`. Users can use this field instead of `endpoints` and `originName` to route different URL paths on a frontend to serve different origins. If `endpointMap` is set, the Proxy will return a 404 error to HTTP requests sent to paths that don't match one of its keys. The proxy will also verify that only one of `endpoint` [deprecated], `endpoints`, and `endpointMap` are set.
-
 	* For example, if you have two origins with names `[adminOrigin, userOrigin]` and want to forward requests to `/admin` and `/user` respectively, on the `Frontend` config, specify `"endpointMap": {"/admin":"adminOrigin", "/user":"userOrigin"}` and do not specify `endpoint` or `endpoints`.
 * Fixed a bug where all custom extensions were assumed to be maps.
 


### PR DESCRIPTION
Due to a syntax error, these were showing up unformatted.

* afc1119 (Jesse Rosenberger, 2 minutes ago)

  ```
  (release notes) Fix formatting of v0.8.10 bullet-points.
  
  The missing line here was causing the bullet-points to show up as a single
  long line.
  
  As seen here: https://cl.ly/3l1I0N0u2X3e
  ```

![image](https://user-images.githubusercontent.com/841294/37524060-6b11a5da-2931-11e8-9389-3593a32c3c2a.png)


And as a rider to this PR:

* 256bba8 (Jesse Rosenberger, 30 seconds ago)
  * (release notes) Remove unnecessary newline in markdown bullets.