### PR TITLE
Document cache headers and CDN integration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,8 +17,9 @@ sidebar_categories:
     - schema-analytics
     - error-tracking
     - caching
-    - reports
     - auto-persisted-queries
+    - cdn
+    - reports
     - query-batching
   Guides:
     - troubleshooting

--- a/source/auto-persisted-queries.md
+++ b/source/auto-persisted-queries.md
@@ -26,7 +26,7 @@ const client = new ApolloClient({
 ```
 2. Upgrade to Apollo Engine 1.0.1 or newer. (Older versions supported APQ but required more configuration.)
 
-3. If your GraphQL server will be hosted on a different origin from where it will be accessed, you'll need to tell Engine what [CORS headers](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to send in order to use APQ. If this step applies to you, then you will have already needed to set up CORS headers inside your app. Generally Engine can just forward your GraphQL server's CORS response headers to clients, but some messages in the APQ protocol don't involve talking to your GraphQL server, so you will need to statically configure Engine instead. (We are hoping to make this more automatic in a future version.) You can do this with the `overrideGraphqlResponseHeaders` options:
+3. If your GraphQL server will be hosted on a different origin from where it will be accessed, you'll need to tell Engine what [CORS headers](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to send in order to use APQ. If this step applies to you, then you will have already needed to set up CORS headers inside your app. Generally Engine can just forward your GraphQL server's CORS response headers to clients, but some messages in the APQ protocol don't involve talking to your GraphQL server, so you will need to statically configure Engine instead. (We are hoping to make this more automatic in a future version.) You can do this with the `overrideGraphqlResponseHeaders` option:
 
 ```
 const engine = new ApolloEngine({

--- a/source/cdn.md
+++ b/source/cdn.md
@@ -57,6 +57,7 @@ Then, add the persisted queries link to your Apollo Client before the HTTP link:
 import { createPersistedQueryLink } from "apollo-link-persisted-queries";
 import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
+import { ApolloLink } from "apollo-link";
 import ApolloClient from "apollo-client";
 
 ApolloLink.from([

--- a/source/cdn.md
+++ b/source/cdn.md
@@ -5,25 +5,28 @@ description: Getting content delivery networks to cache your GraphQL responses
 
 Many high-traffic web services use content-delivery networks such as [Akamai](https://www.akamai.com/) or [Fastly](https://www.fastly.com/) to cache their content as close to their clients as possible. Engine makes it straightforward to use CDNs with GraphQL queries whose responses can be cached while still passing more dynamic queries through to your GraphQL server.
 
-To use Engine behind a CDN, you need to be able to tell the CDN which GraphQL responses it's allowed to cache, and you need to make sure that your GraphQL requests arrive in a format that CDNs cache.  Engine supports this via its [caching](./caching.html) and [automatic persisted queries](./auto-persisted-queries.html) features. This page explains the basic steps for setting up these features to work with CDNs; for more details on how to configure these features, see their respective pages.
+To use Engine behind a CDN, you need to be able to tell the CDN which GraphQL responses it's allowed to cache, and you need to make sure that your GraphQL requests arrive in a format that CDNs cache. Engine supports this via its [caching](./caching.html) and [automatic persisted queries](./auto-persisted-queries.html) features. This page explains the basic steps for setting up these features to work with CDNs; for more details on how to configure these features, see their respective pages.
 
-## Step 1: Enable cache control in your Apollo Server
+<h2 id="enable-cache-control" title="1. Enable cache control">Step 1: Enable cache control in your Apollo Server</h2>
 
-Just add `cacheControl: true` to your Apollo Server middleware invocation, such as `graphqlExpress`. See [the caching docs](./caching.html#enable-cache-control) for more details on enabling Cache Control. Ensure that you are running at least version 1.0.4 of `apollo-server-express` (or your Apollo Server module of choice).  Your call should look something like:
+Just add `cacheControl: true` to your Apollo Server middleware invocation, such as `graphqlExpress`. See [the caching docs](./caching.html#enable-cache-control) for more details on enabling Cache Control. Ensure that you are running at least version 1.0.4 of `apollo-server-express` (or your Apollo Server module of choice). Your call should look something like:
 
 ```js
-app.use('/graphql', bodyParser.json(), graphqlExpress({
-  schema,
-  context: {},
-  tracing: true,
-  cacheControl: true
-}));
+app.use(
+  "/graphql",
+  bodyParser.json(),
+  graphqlExpress({
+    schema,
+    context: {},
+    tracing: true,
+    cacheControl: true
+  })
+);
 ```
 
+<h2 id="cache-hints" title="2. Add cache hints">Step 2: Add cache hints to your GraphQL schema</h2>
 
-## Step 2: Add cache hints to your GraphQL schema
-
-Add cache hints to your GraphQL schema so that Engine knows which fields and types are cacheable and for how long.  For example, to say that all fields that return an `Author` should be cached for 60 seconds, and that the `posts` field should itself be cached for 180 seconds, write this in your schema:
+Add cache hints to your GraphQL schema so that Engine knows which fields and types are cacheable and for how long. For example, to say that all fields that return an `Author` should be cached for 60 seconds, and that the `posts` field should itself be cached for 180 seconds, write this in your schema:
 
 ```graphql
 type Author @cacheControl(maxAge: 60) {
@@ -38,9 +41,17 @@ See [the cache hints docs](./caching.html#cache-hints) for more details on cache
 
 Once you've done these two steps, Engine will serve the HTTP `Cache-Control` header on fully cacheable responses, so that any CDN in front of Engine will know which responses can be cached and for how long! By "fully cacheable", we mean any response containing only data with non-zero `maxAge`; the header will refer to the minimum `maxAge` value across the whole response, and it will be `public` unless some of the data is tagged `scope: PRIVATE`. You should be able to observe this header in your browser's dev tools. Engine will also cache the responses in its own default public in-memory cache.
 
-## Step 3: Enable automatic persisted queries
+<h2 id="enable-apq" title="3. Enable persisted queries">Step 3: Enable automatic persisted queries</h2>
 
-However, your GraphQL requests are still probably big POST requests, and most CDNs will only cache GET requests, and GET requests generally work best if the URL is of a bounded size. To work with this, enable Engine's automatic persisted queries support. This allows clients to send short hashes instead of full queries, and you can configure it to use GET requests for those queries.  In your **client**, run `npm install apollo-link-persisted-queries`, and add the persisted queries link to your Apollo Client before the HTTP link:
+However, your GraphQL requests are still probably big POST requests, and most CDNs will only cache GET requests, and GET requests generally work best if the URL is of a bounded size. To work with this, enable Engine's automatic persisted queries support. This allows clients to send short hashes instead of full queries, and you can configure it to use GET requests for those queries.
+
+To do this, update your **client** code. First, add the package to your app:
+
+```
+npm install apollo-link-persisted-queries
+```
+
+Then, add the persisted queries link to your Apollo Client before the HTTP link:
 
 ```js
 import { createPersistedQueryLink } from "apollo-link-persisted-queries";
@@ -48,16 +59,20 @@ import { createHttpLink } from "apollo-link-http";
 import { InMemoryCache } from "apollo-cache-inmemory";
 import ApolloClient from "apollo-client";
 
-const link = createPersistedQueryLink({useGETForHashedQueries: true}).concat(createHttpLink({ uri: "/graphql" }));
+ApolloLink.from([
+  createPersistedQueryLink({ useGETForHashedQueries: true }),
+  createHttpLink({ uri: "/graphql" })
+]);
+
 const client = new ApolloClient({
   cache: new InMemoryCache(),
-  link: link,
+  link: link
 });
 ```
 
-Make sure not to leave out the `useGETForHashedQueries: true`! Note that your client will still use POSTs for mutations, because it's generally best to avoid GETs for non-idempotent requests.
+Make sure not to leave out the `useGETForHashedQueries: true`. Note that your client will still use POSTs for mutations, because it's generally best to avoid GETs for non-idempotent requests.
 
-If your GraphQL server will be hosted on a different origin from where it will be accessed, you'll need to tell Engine what [CORS headers](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to send in order to use APQ. If this step applies to you, then you will have already needed to set up CORS headers inside your app. Generally Engine can just forward your GraphQL server's CORS response headers to clients, but some messages in the APQ protocol don't involve talking to your GraphQL server, so you will need to statically configure Engine instead. (We are hoping to make this more automatic in a future version.) You can do this with the `overrideGraphqlResponseHeaders` option in your `ApolloEngine` constructor:
+If your GraphQL server will be hosted on a different origin from where it will be accessed, you'll need to tell Engine what [CORS headers](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to send in order to use Automatic Persisted Queries (APQ). If this step applies to you, then you will have already needed to set up CORS headers inside your app. Generally Engine can just forward your GraphQL server's CORS response headers to clients, but some messages in the APQ protocol don't involve talking to your GraphQL server, so you will need to statically configure Engine instead. (We are hoping to make this more automatic in a future version.) You can do this with the `overrideGraphqlResponseHeaders` option in your `ApolloEngine` constructor:
 
 ```
 const engine = new ApolloEngine({
@@ -72,7 +87,6 @@ const engine = new ApolloEngine({
 
 If all is well, you should be able to see in your browser's dev tools that queries are now being sent as GET requests, and are still receiving appropriate `Cache-Control` response headers.
 
-
-## Step 4: Set up your CDN!
+<h2 id="setup-cdn" title="4. Set up your CDN">Step 4: Set up your CDN!</h2>
 
 How exactly this works depends on exactly which CDN you chose. Configure your CDN to send requests to your Engine-powered GraphQL app. For some CDNs, you may need to specially configure your CDN to honor origin Cache-Control headers; for example, here is [Akamai's documentation on that setting](https://learn.akamai.com/en-us/webhelp/ion/oca/GUID-57C31126-F745-4FFB-AA92-6A5AAC36A8DA.html). If all is well, your cacheable queries should now be cached by your CDN! Note that requests served directly by your CDN will not show up in your Engine dashboard.

--- a/source/cdn.md
+++ b/source/cdn.md
@@ -1,0 +1,78 @@
+---
+title: CDN Integration
+description: Getting content delivery networks to cache your GraphQL responses
+---
+
+Many high-traffic web services use content-delivery networks such as [Akamai](https://www.akamai.com/) or [Fastly](https://www.fastly.com/) to cache their content as close to their clients as possible. Engine makes it straightforward to use CDNs with GraphQL queries whose responses can be cached while still passing more dynamic queries through to your GraphQL server.
+
+To use Engine behind a CDN, you need to be able to tell the CDN which GraphQL responses it's allowed to cache, and you need to make sure that your GraphQL requests arrive in a format that CDNs cache.  Engine supports this via its [caching](./caching.html) and [automatic persisted queries](./auto-persisted-queries.html) features. This page explains the basic steps for setting up these features to work with CDNs; for more details on how to configure these features, see their respective pages.
+
+## Step 1: Enable cache control in your Apollo Server
+
+Just add `cacheControl: true` to your Apollo Server middleware invocation, such as `graphqlExpress`. See [the caching docs](./caching.html#enable-cache-control) for more details on enabling Cache Control. Ensure that you are running at least version 1.0.4 of `apollo-server-express` (or your Apollo Server module of choice).  Your call should look something like:
+
+```js
+app.use('/graphql', bodyParser.json(), graphqlExpress({
+  schema,
+  context: {},
+  tracing: true,
+  cacheControl: true
+}));
+```
+
+
+## Step 2: Add cache hints to your GraphQL schema
+
+Add cache hints to your GraphQL schema so that Engine knows which fields and types are cacheable and for how long.  For example, to say that all fields that return an `Author` should be cached for 60 seconds, and that the `posts` field should itself be cached for 180 seconds, write this in your schema:
+
+```graphql
+type Author @cacheControl(maxAge: 60) {
+  id: Int
+  firstName: String
+  lastName: String
+  posts: [Post] @cacheControl(maxAge: 180)
+}
+```
+
+See [the cache hints docs](./caching.html#cache-hints) for more details on cache hints, including how to specify hints dynamically inside resolvers, how to set a default `maxAge` for all fields, and how to specify that a field should be cached for specific users only (in which case CDNs should ignore it).
+
+Once you've done these two steps, Engine will serve the HTTP `Cache-Control` header on fully cacheable responses, so that any CDN in front of Engine will know which responses can be cached and for how long! By "fully cacheable", we mean any response containing only data with non-zero `maxAge`; the header will refer to the minimum `maxAge` value across the whole response, and it will be `public` unless some of the data is tagged `scope: PRIVATE`. You should be able to observe this header in your browser's dev tools. Engine will also cache the responses in its own default public in-memory cache.
+
+## Step 3: Enable automatic persisted queries
+
+However, your GraphQL requests are still probably big POST requests, and most CDNs will only cache GET requests, and GET requests generally work best if the URL is of a bounded size. To work with this, enable Engine's automatic persisted queries support. This allows clients to send short hashes instead of full queries, and you can configure it to use GET requests for those queries.  In your **client**, run `npm install apollo-link-persisted-queries`, and add the persisted queries link to your Apollo Client before the HTTP link:
+
+```js
+import { createPersistedQueryLink } from "apollo-link-persisted-queries";
+import { createHttpLink } from "apollo-link-http";
+import { InMemoryCache } from "apollo-cache-inmemory";
+import ApolloClient from "apollo-client";
+
+const link = createPersistedQueryLink({useGETForHashedQueries: true}).concat(createHttpLink({ uri: "/graphql" }));
+const client = new ApolloClient({
+  cache: new InMemoryCache(),
+  link: link,
+});
+```
+
+Make sure not to leave out the `useGETForHashedQueries: true`! Note that your client will still use POSTs for mutations, because it's generally best to avoid GETs for non-idempotent requests.
+
+If your GraphQL server will be hosted on a different origin from where it will be accessed, you'll need to tell Engine what [CORS headers](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to send in order to use APQ. If this step applies to you, then you will have already needed to set up CORS headers inside your app. Generally Engine can just forward your GraphQL server's CORS response headers to clients, but some messages in the APQ protocol don't involve talking to your GraphQL server, so you will need to statically configure Engine instead. (We are hoping to make this more automatic in a future version.) You can do this with the `overrideGraphqlResponseHeaders` option in your `ApolloEngine` constructor:
+
+```
+const engine = new ApolloEngine({
+  apiKey: process.env.API_KEY,
+  frontends: [{
+    overrideGraphqlResponseHeaders: {
+      'Access-Control-Allow-Origin': '*',
+    },
+  }],
+});
+```
+
+If all is well, you should be able to see in your browser's dev tools that queries are now being sent as GET requests, and are still receiving appropriate `Cache-Control` response headers.
+
+
+## Step 4: Set up your CDN!
+
+How exactly this works depends on exactly which CDN you chose. Configure your CDN to send requests to your Engine-powered GraphQL app. For some CDNs, you may need to specially configure your CDN to honor origin Cache-Control headers; for example, here is [Akamai's documentation on that setting](https://learn.akamai.com/en-us/webhelp/ion/oca/GUID-57C31126-F745-4FFB-AA92-6A5AAC36A8DA.html). If all is well, your cacheable queries should now be cached by your CDN! Note that requests served directly by your CDN will not show up in your Engine dashboard.

--- a/source/index.md
+++ b/source/index.md
@@ -23,6 +23,9 @@ Engine is designed to be your one-stop-shop for GraphQL-specific infrastructure.
 1. [Error tracking](./error-tracking.html)
 1. [Response caching](./caching.html)
 1. [Automatic persisted queries](./auto-persisted-queries.html)
+1. [CDN integration](./cdn.html)
+1. [Daily Slack reports](./reports.html)
+1. [Query batching](./query-batching.html)
 
 <h2 id="components">Engine components</h2>
 

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -13,7 +13,7 @@ This release include a variety of changes related to caching.
 * The Engine Proxy now includes `Cache-Control` headers on responses served from its cache, not just on responses it stores to its cache.
 * The Engine Proxy no longer uses a generic HTTP heuristic to generate a max age limit for responses with the HTTP header `Last-Modified` but no other HTTP-level max age specification. This was added accidentally in v1.0.4 and is not necessary given that we only cache data that explicitly requests it in the GraphQL extension.
 * The Engine Proxy now properly comma-separates fields in generated `Cache-Control` response headers.
-* The warning when trying to insert an item too large into an in-memory cache is now more explicit about the size limit.
+* The warning when trying to insert an oversized item into an in-memory cache is now more explicit about the size limit. (Items in the in-memory cache cannot be larger than approximately 1/1024 of the total cache size.)
 
 <h2 id="v1.0.4" title="v1.0.4">1.0.4 - 2018-03-23</h2>
 

--- a/source/proxy-release-notes.md
+++ b/source/proxy-release-notes.md
@@ -4,6 +4,17 @@ title: Proxy release notes
 
 The versions given here are both for the [`apollo-engine` Node.js package](https://www.npmjs.com/package/apollo-engine) and the `gcr.io/mdg-public/engine` Docker container.
 
+<h2 id="v1.0.5" title="v1.0.5">1.0.5 - 2018-04-05</h2>
+
+This release include a variety of changes related to caching.
+
+* The Engine Proxy now observes the `Vary` header in HTTP responses. See the new [documentation of cache header support](./caching.html#http-headers) for more details.
+* The Engine Proxy now explicitly requests that "persisted query not found" responses are not cached by CDNs or browsers. (Typically these responses are followed by the client informing Engine of the full matching query, so caching the not-found response was effectively cache poisoning.)
+* The Engine Proxy now includes `Cache-Control` headers on responses served from its cache, not just on responses it stores to its cache.
+* The Engine Proxy no longer uses a generic HTTP heuristic to generate a max age limit for responses with the HTTP header `Last-Modified` but no other HTTP-level max age specification. This was added accidentally in v1.0.4 and is not necessary given that we only cache data that explicitly requests it in the GraphQL extension.
+* The Engine Proxy now properly comma-separates fields in generated `Cache-Control` response headers.
+* The warning when trying to insert an item too large into an in-memory cache is now more explicit about the size limit.
+
 <h2 id="v1.0.4" title="v1.0.4">1.0.4 - 2018-03-23</h2>
 
 * The Engine Proxy now will compress responses to GraphQL queries by default if the client sends the standard HTTP `Accept-Encoding: gzip` header. You can disable this by passing `frontends: [{responseCompression: {disabled: true}}]` to the `ApolloEngine` constructor. (The Engine Proxy continues to accept compressed responses from your GraphQL origin by default as well.) Engine will never proactively compress responses to requests on non-GraphQL paths but will pass through any compression applied by the server it is proxying to.


### PR DESCRIPTION
The CDN integration page doesn't have much unique information: it's mostly a
digested form of the caching and persisted queries features you need to set up
to get it to work.