### PR TITLE
hyphen nits

### DIFF
--- a/source/datadog.md
+++ b/source/datadog.md
@@ -11,8 +11,8 @@ Apollo Engine is designed to monitor the performance of your GraphQL infrastruct
 The Datadog metrics provided are:
 
 * `apollo.engine.operations.count` – the number of GraphQL operations that were executed. This includes queries, mutations, and operations that resulted in an error.
-* `apollo.engine.operations.error_count`-  the number of GraphQL operations that resulted in an error. This includes GraphQL execution errors, and HTTP errors if Engine failed to connect to your server.
-* `apollo.engine.operations.cache_hit_count` - the number of GraphQL queries whose result was served from Apollo Engine's full query cache.
+* `apollo.engine.operations.error_count` – the number of GraphQL operations that resulted in an error. This includes GraphQL execution errors, and HTTP errors if Engine failed to connect to your server.
+* `apollo.engine.operations.cache_hit_count` – the number of GraphQL queries whose result was served from Apollo Engine's full query cache.
 * A histogram of GraphQL operation response times, measured in milliseconds. Due to Engine's aggregation method (logarithmic binning), these values are accurate to +/- 5%:
   * `apollo.engine.operations.latency.min`
   * `apollo.engine.operations.latency.median`

--- a/source/datadog.md
+++ b/source/datadog.md
@@ -10,9 +10,9 @@ Apollo Engine is designed to monitor the performance of your GraphQL infrastruct
 
 The Datadog metrics provided are:
 
-* `apollo.engine.operations.count` – the number of GraphQL operations that were executed. This includes queries, mutations, and operations that resulted in an error.
-* `apollo.engine.operations.error_count` – the number of GraphQL operations that resulted in an error. This includes GraphQL execution errors, and HTTP errors if Engine failed to connect to your server.
-* `apollo.engine.operations.cache_hit_count` – the number of GraphQL queries whose result was served from Apollo Engine's full query cache.
+* `apollo.engine.operations.count` --- the number of GraphQL operations that were executed. This includes queries, mutations, and operations that resulted in an error.
+* `apollo.engine.operations.error_count` --- the number of GraphQL operations that resulted in an error. This includes GraphQL execution errors, and HTTP errors if Engine failed to connect to your server.
+* `apollo.engine.operations.cache_hit_count` --- the number of GraphQL queries whose result was served from Apollo Engine's full query cache.
 * A histogram of GraphQL operation response times, measured in milliseconds. Due to Engine's aggregation method (logarithmic binning), these values are accurate to +/- 5%:
   * `apollo.engine.operations.latency.min`
   * `apollo.engine.operations.latency.median`


### PR DESCRIPTION
Use longdash consistently, and use the same whitespace on each entry.